### PR TITLE
Performance improvements for busy clusters

### DIFF
--- a/cmd/sciuro/main.go
+++ b/cmd/sciuro/main.go
@@ -35,6 +35,9 @@ type config struct {
 	DevMode bool `env:"SCIURO_DEV_MODE" envDefault:"false"`
 	// ReconcileTimeout is the maximum time given to reconcile a node.
 	ReconcileTimeout time.Duration `env:"SCIURO_RECONCILE_TIMEOUT" envDefault:"45s"`
+	// MaxConcurrentReconciles is the maximum number of nodes which can be
+	// reconciled concurrently.
+	MaxConcurrentReconciles int `env:"SCIURO_MAX_CONCURRENT_RECONCILES" envDefault:"1"`
 	// AlertReceiver is the receiver to use for server-side filtering of alerts
 	// must be the same across all targeted nodes in the cluster
 	AlertReceiver string `env:"SCIURO_ALERT_RECEIVER,required"`
@@ -121,7 +124,8 @@ func main() {
 		)
 
 		c, err := controller.New("node-status-controller", mgr, controller.Options{
-			Reconciler: r,
+			MaxConcurrentReconciles: cfg.MaxConcurrentReconciles,
+			Reconciler:              r,
 		})
 		if err != nil {
 			entryLog.Error(err, "unable to set up individual controller")

--- a/cmd/sciuro/main.go
+++ b/cmd/sciuro/main.go
@@ -74,7 +74,6 @@ func main() {
 	entryLog := log.WithName("entrypoint")
 
 	mgr, err := manager.New(clientconfig.GetConfigOrDie(), manager.Options{
-		SyncPeriod:              &cfg.NodeResync,
 		LeaderElection:          true,
 		LeaderElectionID:        cfg.LeaderElectionID,
 		LeaderElectionNamespace: cfg.LeaderElectionNamespace,
@@ -118,6 +117,7 @@ func main() {
 			mgr.GetClient(),
 			log.WithName("reconciler"),
 			metrics.Registry,
+			cfg.NodeResync,
 			cfg.ReconcileTimeout,
 			cfg.LingerResolvedDuration,
 			as,

--- a/internal/node/reconciler_test.go
+++ b/internal/node/reconciler_test.go
@@ -30,6 +30,7 @@ var (
 )
 
 func Test_Reconcile(t *testing.T) {
+	const resyncInterval = 2 * time.Minute
 	tests := []struct {
 		name        string
 		updateMocks func(c *mockK8SClient, cache *mockAlertCache)
@@ -85,7 +86,7 @@ func Test_Reconcile(t *testing.T) {
 				}
 				c.On("Patch", mock.Anything, mock.MatchedBy(match), mock.Anything, mock.Anything).Return(nil)
 			},
-			want:    reconcile.Result{},
+			want:    reconcile.Result{RequeueAfter: resyncInterval},
 			wantErr: false,
 		},
 		{
@@ -129,7 +130,7 @@ func Test_Reconcile(t *testing.T) {
 					},
 				).Return(nil)
 			},
-			want:    reconcile.Result{},
+			want:    reconcile.Result{RequeueAfter: resyncInterval},
 			wantErr: false,
 		},
 	}
@@ -141,7 +142,7 @@ func Test_Reconcile(t *testing.T) {
 			c := &mockK8SClient{}
 			ac := &mockAlertCache{}
 			tt.updateMocks(c, ac)
-			n := NewNodeStatusReconciler(c, logr.Discard(), prometheus.NewRegistry(), time.Minute, time.Minute, ac)
+			n := NewNodeStatusReconciler(c, logr.Discard(), prometheus.NewRegistry(), resyncInterval, time.Minute, time.Minute, ac)
 			got, err := n.Reconcile(context.Background(), request)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Changes:
1. Make MaxConcurrentReconciles tunable. This controller-runtime option
controls how many nodes can be reconciled concurrently. It defaults to
1, but can be safely increased to increase throughput.
2. Use RequeueAfter to poll instead of SyncPeriod. When polling for
changes to resources which can't be watched (i.e. current alerts in
alertmanager), controller-runtime recommends setting RequeueAfter
individually on each result over reducing the global SyncPeriod. This
reduces load on the API server, and avoids re-reconciling any resources
which have already been reconciled within the polling interval for
another reason, such as a watch event. 