### PR TITLE
fix(rbac): Add permissions for leader election to create events

### DIFF
--- a/manifests/namespaced/role.yaml
+++ b/manifests/namespaced/role.yaml
@@ -24,3 +24,11 @@ rules:
   - patch
   - get
   - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list


### PR DESCRIPTION
When the leader changes, an error is emitted by the pods:
```
events is forbidden: User "system:serviceaccount:node-remediation:sciuro" cannot create resource "events" in API group
```