### PR TITLE
fix(tools): add --tags to print-workspace-status

### DIFF
--- a/tools/print-workspace-status
+++ b/tools/print-workspace-status
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-echo STABLE_GIT_TAG $(git describe --always --match "v[0-9].*" --dirty)
+echo STABLE_GIT_TAG $(git describe --always --tags --match "v[0-9].*" --dirty)


### PR DESCRIPTION
Without --tags, this command was returning an old dirty tag which wasn't properly tagging the container in docker hub.