### PR TITLE
refactor(syncer): use cel type to match expression

### DIFF
--- a/internal/alert/BUILD.bazel
+++ b/internal/alert/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "@com_github_go_logr_logr//:logr",
         "@com_github_google_cel_go//cel:go_default_library",
         "@com_github_google_cel_go//checker/decls:go_default_library",
+        "@com_github_google_cel_go//common/types:go_default_library",
         "@com_github_prometheus_alertmanager//api/v2/client",
         "@com_github_prometheus_alertmanager//api/v2/client/alert",
         "@com_github_prometheus_alertmanager//api/v2/models",

--- a/internal/alert/sync.go
+++ b/internal/alert/sync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
 	"github.com/prometheus/alertmanager/api/v2/client"
 	"github.com/prometheus/alertmanager/api/v2/client/alert"
 	"github.com/prometheus/alertmanager/api/v2/models"
@@ -153,13 +154,9 @@ func (s *syncer) Get(nodeName string) ([]promv1.Alert, time.Time, error) {
 			"ShortName": strings.Split(nodeName, ".")[0],
 		})
 		if err != nil {
-			return nil, s.retrievedAt, err
+			return nil, s.retrievedAt, fmt.Errorf("cel evaluation error: %w", err)
 		}
-		matched, ok := out.Value().(bool)
-		if !ok {
-			return nil, s.retrievedAt, fmt.Errorf("result of provided CLE expression was not a boolean")
-		}
-		if matched {
+		if out == types.True {
 			matchedAlerts = append(matchedAlerts, al)
 		}
 	}


### PR DESCRIPTION
Instead of casting the value to a bool, use types.True.