### PR TITLE
docs: update CEL expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ SCIURO_ALERT_RECEIVER: "CHANGEME"
 # `labels` is a map representing the prometheus labels of the alert.
 # There are two other valid variables available for substitution:
 # `FullName` and `ShortName` where `ShortName` is `FullName` up to the first . (dot)
-SCIURO_CEL_EXPRESSION: `labels["node"] == FullName || labels["node"] == ShortName`
+SCIURO_CEL_EXPRESSION: `"node" in labels && (labels["node"] == FullName || labels["node"] == ShortName)`
 ```
 
 Some additional optional settings are as follows:

--- a/manifests/namespaced/configmap.yaml
+++ b/manifests/namespaced/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
 data:
   SCIURO_ALERT_RECEIVER: CHANGEME
   SCIURO_ALERTMANAGER_URL: https://CHANGEME.example.com
-  SCIURO_CEL_EXPRESSION: labels["instance"] == FullName || labels["instance"] == ShortName
+  SCIURO_CEL_EXPRESSION: '"node" in labels && (labels["node"] == FullName || labels["node"] == ShortName)'


### PR DESCRIPTION
The CEL expression will fail if an alert does not include the label.

Suggest that the map be checked for a keys existence first.