### PR TITLE
ci: adopt golangci-lint v2

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,58 +1,17 @@
+version: "2"
+
 run:
   timeout: 5m
-  modules-download-mode: readonly
 
 linters:
-  enable:
-    - bodyclose
-    - contextcheck
-    - copyloopvar
-    - decorder
-    - dogsled
-    - errcheck
-    - errorlint
-    - gochecknoinits
-    - goconst
-    - gocritic
-    - godox
-    - goimports
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - misspell
-    - nakedret
-    - prealloc
-    - revive
-    - staticcheck
-    - stylecheck
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-linters-settings:
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - commentFormatting
-      - exitAfterDefer
-      - hugeParam
-      - ifElseChain
-      - rangeValCopy
-      - unnecessaryBlock
-  gofmt:
-    simplify: true
-  misspell:
-    locale: US
-    ignore-words:
-      - clas
-  godox:
-    keywords:
-      - HACK
-      - XXX
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+
+formatters:
+  exclusions:
+    generated: lax

--- a/internal/node/reconciler_test.go
+++ b/internal/node/reconciler_test.go
@@ -191,7 +191,7 @@ func Test_Reconcile(t *testing.T) {
 			}
 			mock.AssertExpectationsForObjects(t, ac)
 			actual := &corev1.Node{}
-			assert.NilError(t, c.Get(context.TODO(), types.NamespacedName{Name: tt.expected.ObjectMeta.Name}, actual))
+			assert.NilError(t, c.Get(context.TODO(), types.NamespacedName{Name: tt.expected.Name}, actual))
 			assert.DeepEqual(t, tt.expected, actual,
 				cmpopts.IgnoreFields(v1.ObjectMeta{}, "ResourceVersion"),
 				cmpopts.IgnoreTypes(v1.TypeMeta{}))


### PR DESCRIPTION
v2 is the current major release with an improved config schema and linter set; moving the config onto it keeps us on the maintained line. It also unblocks CI, since golangci-lint-action installs the latest release and v2 cannot load the old v1 config format.