### PR TITLE
fix(manifests): tolerate objects without a trailing newline

### DIFF
--- a/manifests/BUILD.bazel
+++ b/manifests/BUILD.bazel
@@ -3,7 +3,7 @@ genrule(
     name = "stable",
     srcs = ["//manifests/namespaced:objects"],
     outs = ["stable.yaml"],
-    cmd = "for f in $$(printf '%s\\n' $(locations //manifests/namespaced:objects) | sort); do echo '---'; cat $$f; done > $@",
+    cmd = "for f in $$(printf '%s\\n' $(locations //manifests/namespaced:objects) | sort); do echo '---'; cat $$f; [ -z \"$$(tail -c1 $$f)\" ] || echo; done > $@",
     visibility = ["//visibility:public"],
 )
 
@@ -11,6 +11,6 @@ genrule(
     name = "cluster",
     srcs = ["//manifests/non-namespaced:objects"],
     outs = ["cluster.yaml"],
-    cmd = "for f in $$(printf '%s\\n' $(locations //manifests/non-namespaced:objects) | sort); do echo '---'; cat $$f; done > $@",
+    cmd = "for f in $$(printf '%s\\n' $(locations //manifests/non-namespaced:objects) | sort); do echo '---'; cat $$f; [ -z \"$$(tail -c1 $$f)\" ] || echo; done > $@",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The release job renders stable.yaml/cluster.yaml by concatenating each object after an `echo '---'`. When a source object lacks a trailing newline the following separator lands on that object's last line (e.g. `name: sciuro-leader---`), yielding a stream that strict YAML parsers reject with a duplicate-key error. Append a newline after any object that lacks one so the separator always starts its own line.

Reviewed-by: Andrew DeMaria